### PR TITLE
Updated url regex to match with new skillshare URLs

### DIFF
--- a/skillshare.py
+++ b/skillshare.py
@@ -24,7 +24,7 @@ class Skillshare(object):
             return False
 
     def download_course_by_url(self, url):
-        m = re.match(r'https://www.skillshare.com/classes/.*?/(\d+)', url)
+        m = re.match(r'https://www.skillshare.com.*?/(\d+)', url)
 
         if not m:
             raise Exception('Failed to parse class ID from URL')


### PR DESCRIPTION
Skillshare seems to have updated its URL schemes recently and has broken the regex used to parse the course ID from a course URL. This pull request updates the regex to work with both old an new URLs.

Here is the same regex and some tests on [regex101](https://regex101.com/library/F5nrXV)