### PR TITLE
Fix: Add missing 'requests' module dependency in dl.py

### DIFF
--- a/dl.py
+++ b/dl.py
@@ -1,4 +1,4 @@
-import sys, os
+import requests, sys, os
 from skillshare import Skillshare, splash
 from magic import cookie
 


### PR DESCRIPTION
This update ensures that the 'requests' module is included as a dependency, preventing import errors when dl.py is executed.

```
Traceback (most recent call last):
  File "/root/.Skillshare-DL/dl.py", line 2, in <module>
    from skillshare import Skillshare, splash
  File "/root/.Skillshare-DL/skillshare.py", line 1, in <module>
    import requests, json, sys, re, os
ModuleNotFoundError: No module named 'requests'
```